### PR TITLE
Add msg.count_topics to Average node output.

### DIFF
--- a/average.html
+++ b/average.html
@@ -13,7 +13,7 @@
     <p>Calculate the average of incoming <code>msg.payload</code> values from across a number of different <code>msg.topic</code>.</p>
     <p>Incoming <code>msg.topic</code> has to be used to separate and identify values.
     Messages not containing a valid numeric value will be rejected.</p>
-    <p>Will return the current average of all different <code>msg.topic</code> values as <code>msg.payload</code>.
+    <p>Will return the current average of all different <code>msg.topic</code> values as <code>msg.payload</code>, and the number of different <code>msg.topic</code> used to calculate <code>msg.payload</code> as <code>msg.topics_count</code>.
     Every other properties of incoming message will be pushed through.</p>
     <p>The average can be reset with an incoming message that contains <code>msg.reset</code>.
     Then all stored data will be removed and the initial average starts at zero again.</p>

--- a/average.js
+++ b/average.js
@@ -31,6 +31,8 @@ module.exports = function(RED) {
                     }, 0);
 
                     msg.payload = sum / amount;
+                    
+                    msg.amount = amount;
 
                     // overwrite topic if configured
                     if( node.topic ) {

--- a/average.js
+++ b/average.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
 
                     msg.payload = sum / amount;
                     
-                    msg.count_topics = amount;
+                    msg.topics_count = amount;
 
                     // overwrite topic if configured
                     if( node.topic ) {

--- a/average.js
+++ b/average.js
@@ -32,7 +32,7 @@ module.exports = function(RED) {
 
                     msg.payload = sum / amount;
                     
-                    msg.amount = amount;
+                    msg.count_topics = amount;
 
                     // overwrite topic if configured
                     if( node.topic ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-average",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A Node-RED node to calculate average.",
   "homepage": "http://github.com/dkern/node-red-average",
   "bugs": "http://github.com/dkern/node-red-average/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-average",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A Node-RED node to calculate average.",
   "homepage": "http://github.com/dkern/node-red-average",
   "bugs": "http://github.com/dkern/node-red-average/issues",

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Calculate the average of incoming `msg.payload` values from across a number of d
 Incoming `msg.topic` has to be used to separate and identify values.
 Messages not containing a valid numeric value will be rejected.
 
-Will return the current average of all different `msg.topic` values as `msg.payload` the number of different `msg.topic` used to calculate the avergae in `msg.amount`.
+Will return the current average of all different `msg.topic` values as `msg.payload` and the number of different `msg.topic` used to calculate the avergae in `msg.amount`.
 Every other data will be pushed through.
 
 The average can be reset with an incoming message that contains `msg.reset`.

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Calculate the average of incoming `msg.payload` values from across a number of d
 Incoming `msg.topic` has to be used to separate and identify values.
 Messages not containing a valid numeric value will be rejected.
 
-Will return the current average of all different `msg.topic` values as `msg.payload`.
+Will return the current average of all different `msg.topic` values as `msg.payload` the number of different `msg.topic` used to calculate the avergae in `msg.amount`.
 Every other data will be pushed through.
 
 The average can be reset with an incoming message that contains `msg.reset`.

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Calculate the average of incoming `msg.payload` values from across a number of d
 Incoming `msg.topic` has to be used to separate and identify values.
 Messages not containing a valid numeric value will be rejected.
 
-Will return the current average of all different `msg.topic` values as `msg.payload` and the number of different `msg.topic` used to calculate the avergae in `msg.amount`.
+Will return the current average of all different `msg.topic` values as `msg.payload` and the number of different `msg.topic` used to calculate the avergae in `msg.count_topics`.
 Every other data will be pushed through.
 
 The average can be reset with an incoming message that contains `msg.reset`.

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ Calculate the average of incoming `msg.payload` values from across a number of d
 Incoming `msg.topic` has to be used to separate and identify values.
 Messages not containing a valid numeric value will be rejected.
 
-Will return the current average of all different `msg.topic` values as `msg.payload` and the number of different `msg.topic` used to calculate the avergae in `msg.count_topics`.
+Will return the current average of all different `msg.topic` values as `msg.payload`, and the number of different `msg.topic` used to calculate the `msg.payload` as `msg.topics_count`.
 Every other data will be pushed through.
 
 The average can be reset with an incoming message that contains `msg.reset`.


### PR DESCRIPTION
Hello,

I added `msg.count_topics` to the output of Average object to get a sense of the number of values used to calculate the average.

My use case case is that I have x nodes on the input not arriving at the same time and want to filter out the output to ensure that all x nodes have sent their value before propagating the average.

I thought it could be useful for others.

Regards,

Yanik